### PR TITLE
Each user's profile detail pages

### DIFF
--- a/client/src/common/components/ContactButton.tsx
+++ b/client/src/common/components/ContactButton.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+
+const ContactButton: React.FunctionComponent<{
+	name: string | undefined;
+	publicEmail: string | undefined;
+}> = ({ name, publicEmail }) => {
+	const [copyMessage, setCopyMessage] = useState<string | null>(null);
+
+	const handleContactBtnClick = () => {
+		const email = publicEmail;
+		if (email) {
+			navigator.clipboard
+				.writeText(email)
+				.then(() => {
+					setCopyMessage(`${name}'s contact is copied!`);
+					setTimeout(() => setCopyMessage(null), 3000);
+				})
+				.catch((err) => {
+					setCopyMessage(`Something went wrong...Please try again`);
+					setTimeout(() => setCopyMessage(null), 3000);
+					console.error(err);
+				});
+		} else {
+			setCopyMessage(`Sorry...the contact is not provided yet.`);
+			setTimeout(() => setCopyMessage(null), 3000);
+		}
+	};
+
+	return (
+		<div className="flex flex-col items-center">
+			<button
+				className="bg-primary_title_color self-center my-2 px-6 py-2 text-white rounded-full cursor-pointer inline-block text-sm md:text-base"
+				onClick={handleContactBtnClick}
+			>
+				Contact {name}
+			</button>
+			<span className="text-primary_title_color text-sm md:text-base">
+				{copyMessage}
+			</span>
+		</div>
+	);
+};
+
+export default ContactButton;

--- a/client/src/common/components/Detail.tsx
+++ b/client/src/common/components/Detail.tsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const Detail = () => {
-  return <div>This is Detail</div>;
-};
-
-export default Detail;

--- a/client/src/common/components/KohaiDetail.tsx
+++ b/client/src/common/components/KohaiDetail.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useAppSelector } from '../../app/hook';
 import { RiUser3Fill, MdEmail } from 'react-icons/all';
 import { IKohai } from '../../interfaces/profile';
+import ContactButton from './ContactButton';
 
 const KohaiDetail = () => {
 	const { id } = useParams();
@@ -76,6 +77,10 @@ const KohaiDetail = () => {
 						</div>
 					</article>
 				</section>
+				<ContactButton
+					name={profileNameDisplay()}
+					publicEmail={targetUser?.publicEmail}
+				/>
 			</div>
 		</div>
 	);

--- a/client/src/common/components/KohaiDetail.tsx
+++ b/client/src/common/components/KohaiDetail.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const KohaiDetail = () => {
+	return <div>This is Detail</div>;
+};
+
+export default KohaiDetail;

--- a/client/src/common/components/KohaiDetail.tsx
+++ b/client/src/common/components/KohaiDetail.tsx
@@ -1,7 +1,84 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAppSelector } from '../../app/hook';
+import { RiUser3Fill, MdEmail } from 'react-icons/all';
+import { IKohai } from '../../interfaces/profile';
 
 const KohaiDetail = () => {
-	return <div>This is Detail</div>;
+	const { id } = useParams();
+	const users = useAppSelector((state) => state.users.users);
+	const [targetUser, setTargetUser] = useState<IKohai | null>(null);
+
+	useEffect(() => {
+		if (users)
+			setTargetUser(
+				users.find(
+					(user: { kohaiProfile: { id: string | undefined } }) =>
+						user.kohaiProfile.id === id
+				)
+			);
+	}, [users, id]);
+
+	const profileNameDisplay = () => {
+		return targetUser?.name === ''
+			? `Kohai#${targetUser?.kohaiProfile.id.slice(0, 5)}`
+			: targetUser?.name;
+	};
+
+	const publicEmailDisplay = () => {
+		return !targetUser?.publicEmail
+			? 'Contact is not provided yet'
+			: targetUser?.publicEmail;
+	};
+	return (
+		<div className="bg-secondary_bg_color w-full min-h-screen pt-mobileHeaderHeight lg:pt-laptopHeaderHeight">
+			<div className="container max-w-xl mx-auto py-paddingAroundtheContent px-6 sm:px-8 flex flex-col gap-y-6">
+				<section className="flex flex-wrap gap-x-8 gap-y-4 relative">
+					<img
+						src={targetUser?.profileImage}
+						alt="profile"
+						className="object-cover w-28 h-28 md:w-40 md:h-40 lg:w-48 lg:h-48 rounded-full"
+					/>
+					<div className="flex flex-col justify-center">
+						<h1 className="text-xl font-bold mb-3">{profileNameDisplay()}</h1>
+						<article>
+							<div className="flex items-center gap-x-2">
+								<RiUser3Fill />
+								<span>Kohai</span>
+							</div>
+							<div className="flex items-center gap-x-2">
+								<MdEmail />
+								<span>{publicEmailDisplay()}</span>
+							</div>
+						</article>
+					</div>
+				</section>
+				<section className="flex flex-col gap-y-6">
+					<article>
+						<h2 className="font-bold mb-1">Skills</h2>
+						<div className="bg-white rounded p-4 min-h-6">
+							{targetUser?.kohaiProfile.techStack.map(
+								(skill: String, index: Number) => (
+									<div
+										key={`${index}`}
+										className="inline-block mx-1 my-2 px-2 rounded-full bg-tertiary_bg_color"
+									>
+										{skill}
+									</div>
+								)
+							)}
+						</div>
+					</article>
+					<article>
+						<h2 className="font-bold mb-1">Description</h2>
+						<div className="whitespace-pre-line bg-white rounded p-4 min-h-12">
+							{targetUser?.kohaiProfile.description}
+						</div>
+					</article>
+				</section>
+			</div>
+		</div>
+	);
 };
 
 export default KohaiDetail;

--- a/client/src/common/components/KohaiDetail.tsx
+++ b/client/src/common/components/KohaiDetail.tsx
@@ -31,7 +31,7 @@ const KohaiDetail = () => {
 			? 'Contact is not provided yet'
 			: targetUser?.publicEmail;
 	};
-	return (
+	return targetUser ? (
 		<div className="bg-secondary_bg_color w-full min-h-screen pt-mobileHeaderHeight lg:pt-laptopHeaderHeight">
 			<div className="container max-w-xl mx-auto py-paddingAroundtheContent px-6 sm:px-8 flex flex-col gap-y-6">
 				<section className="flex flex-wrap gap-x-8 gap-y-4 relative">
@@ -83,6 +83,10 @@ const KohaiDetail = () => {
 				/>
 			</div>
 		</div>
+	) : (
+		<h1 className="pt-mobileHeaderHeight lg:pt-laptopHeaderHeight">
+			Page Not Found
+		</h1>
 	);
 };
 

--- a/client/src/common/components/SenpaiDetail.tsx
+++ b/client/src/common/components/SenpaiDetail.tsx
@@ -32,7 +32,7 @@ const SenpaiDetail = () => {
 			: targetUser?.publicEmail;
 	};
 
-	return (
+	return targetUser ? (
 		<div className="bg-primary_bg_color w-full min-h-screen pt-mobileHeaderHeight lg:pt-laptopHeaderHeight">
 			<div className="container max-w-xl mx-auto py-paddingAroundtheContent px-6 sm:px-8 flex flex-col gap-y-6">
 				<section className="flex flex-wrap gap-x-8 gap-y-4 relative">
@@ -84,6 +84,10 @@ const SenpaiDetail = () => {
 				/>
 			</div>
 		</div>
+	) : (
+		<h1 className="pt-mobileHeaderHeight lg:pt-laptopHeaderHeight">
+			Page Not Found!
+		</h1>
 	);
 };
 

--- a/client/src/common/components/SenpaiDetail.tsx
+++ b/client/src/common/components/SenpaiDetail.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAppSelector } from '../../app/hook';
+import { FaUserNinja, MdEmail } from 'react-icons/all';
+
+const SenpaiDetail = () => {
+	const { id } = useParams();
+	const users = useAppSelector((state) => state.users.users);
+	const [targetUser, setTargetUser] = useState<{
+		name: string;
+		profileImage: string;
+		senpaiProfile: {
+			id: string;
+			description: string;
+			techStack: string[];
+		};
+		publicEmail: string;
+	} | null>(null);
+
+	useEffect(() => {
+		if (users)
+			setTargetUser(
+				users.find(
+					(user: { senpaiProfile: { id: string | undefined } }) =>
+						user.senpaiProfile.id === id
+				)
+			);
+	}, [users, id]);
+
+	const profileNameDisplay = () => {
+		return targetUser?.name === ''
+			? `Senpai#${targetUser?.senpaiProfile.id.slice(0, 5)}`
+			: targetUser?.name;
+	};
+
+	const publicEmailDisplay = () => {
+		return !targetUser?.publicEmail
+			? 'Contact is not provided yet'
+			: targetUser?.publicEmail;
+	};
+
+	return (
+		<div className="bg-primary_bg_color w-full min-h-screen pt-mobileHeaderHeight lg:pt-laptopHeaderHeight">
+			<div className="container max-w-xl mx-auto py-paddingAroundtheContent px-6 sm:px-8 flex flex-col gap-y-6">
+				<section className="flex flex-wrap gap-x-8 gap-y-4 relative">
+					<img
+						src={targetUser?.profileImage}
+						alt="profile"
+						className="object-cover w-28 h-28 md:w-40 md:h-40 lg:w-48 lg:h-48 rounded-full"
+					/>
+					<div className="flex flex-col justify-center">
+						<h1 className="text-xl font-bold mb-3">{profileNameDisplay()}</h1>
+						<article>
+							<div className="flex items-center gap-x-2">
+								<FaUserNinja />
+								<span>Senpai</span>
+							</div>
+							<div className="flex items-center gap-x-2">
+								<MdEmail />
+								<span>{publicEmailDisplay()}</span>
+							</div>
+						</article>
+					</div>
+				</section>
+				<section className="flex flex-col gap-y-6">
+					<article>
+						<h2 className="font-bold mb-1">Skills</h2>
+						<div className="bg-white rounded p-4 min-h-6">
+							{targetUser?.senpaiProfile.techStack.map(
+								(skill: String, index: Number) => (
+									<div
+										key={`${index}`}
+										className="inline-block mx-1 my-2 px-2 rounded-full bg-tertiary_bg_color"
+									>
+										{skill}
+									</div>
+								)
+							)}
+						</div>
+					</article>
+					<article>
+						<h2 className="font-bold mb-1">Description</h2>
+						<div className="whitespace-pre-line bg-white rounded p-4 min-h-12">
+							{targetUser?.senpaiProfile.description}
+						</div>
+					</article>
+				</section>
+			</div>
+		</div>
+	);
+};
+
+export default SenpaiDetail;

--- a/client/src/common/components/SenpaiDetail.tsx
+++ b/client/src/common/components/SenpaiDetail.tsx
@@ -2,20 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAppSelector } from '../../app/hook';
 import { FaUserNinja, MdEmail } from 'react-icons/all';
+import { ISenpai } from '../../interfaces/profile';
 
 const SenpaiDetail = () => {
 	const { id } = useParams();
 	const users = useAppSelector((state) => state.users.users);
-	const [targetUser, setTargetUser] = useState<{
-		name: string;
-		profileImage: string;
-		senpaiProfile: {
-			id: string;
-			description: string;
-			techStack: string[];
-		};
-		publicEmail: string;
-	} | null>(null);
+	const [targetUser, setTargetUser] = useState<ISenpai | null>(null);
 
 	useEffect(() => {
 		if (users)

--- a/client/src/common/components/SenpaiDetail.tsx
+++ b/client/src/common/components/SenpaiDetail.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useAppSelector } from '../../app/hook';
 import { FaUserNinja, MdEmail } from 'react-icons/all';
 import { ISenpai } from '../../interfaces/profile';
+import ContactButton from './ContactButton';
 
 const SenpaiDetail = () => {
 	const { id } = useParams();
@@ -77,6 +78,10 @@ const SenpaiDetail = () => {
 						</div>
 					</article>
 				</section>
+				<ContactButton
+					name={profileNameDisplay()}
+					publicEmail={targetUser?.publicEmail}
+				/>
 			</div>
 		</div>
 	);

--- a/client/src/config/routes.ts
+++ b/client/src/config/routes.ts
@@ -9,7 +9,8 @@ import SignUp from '../features/signup/SignUp';
 import ForgotPassword from '../features/forgotpassword/ForgotPassword';
 import ForgotPasswordMessage from '../features/forgotpassword/ForgotPasswordMessage';
 import ForgotPasswordReset from '../features/forgotpassword/ForgotPasswordReset';
-import Detail from '../common/components/Detail';
+import SenpaiDetail from '../common/components/SenpaiDetail';
+import KohaiDetail from '../common/components/KohaiDetail';
 
 const routes: IRoute[] = [
 	{
@@ -79,10 +80,16 @@ const routes: IRoute[] = [
 		component: ForgotPasswordReset,
 	},
 	{
-		path: 'profile/:id',
-		name: 'Detail',
+		path: 'profile/senpai/:id',
+		name: 'Senpai Detail',
 		protected: true,
-		component: Detail,
+		component: SenpaiDetail,
+	},
+	{
+		path: 'profile/kohai/:id',
+		name: 'Kohai Detail',
+		protected: true,
+		component: KohaiDetail,
 	},
 ];
 

--- a/client/src/interfaces/profile.ts
+++ b/client/src/interfaces/profile.ts
@@ -1,0 +1,21 @@
+export interface ISenpai {
+	name: string;
+	profileImage: string;
+	senpaiProfile: {
+		id: string;
+		description: string;
+		techStack: string[];
+	};
+	publicEmail: string;
+}
+
+export interface IKohai {
+	name: string;
+	profileImage: string;
+	kohaiProfile: {
+		id: string;
+		description: string;
+		techStack: string[];
+	};
+	publicEmail: string;
+}


### PR DESCRIPTION
I created each user's profile page.

The user can view these pages when clicking one profile card on the browsing page.
I created this assuming that the senpai profile card has the link with `/senpai/<senpaiProfileid>` path & the kohai profile card has the link with `/kohai/<kohaiProfileid>` path.
@miyabitanimchi Please refer to `client/src/config/routes.ts`.

Each profile page has a button at the bottom of the page.  You can copy the user's email address to the clipboard by clicking it. There should be a message showing up for 3 sec.

Also, when the id is invalid the page shows "Page Not Found" for now, but we'll replace it with 404 page 💪 

Thanks!