### PR TITLE
fix authorization

### DIFF
--- a/server/controllers/authorization.js
+++ b/server/controllers/authorization.js
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import User from '../models/userModels.js';
 
 export const authorization_get = async (req, res) => {
 	const token = req.cookies.access_token;
@@ -7,7 +8,12 @@ export const authorization_get = async (req, res) => {
 	if (token) {
 		try {
 			const decodedToken = await jwt.verify(token, process.env.TOKEN_SECRET);
-			res.status(201).json({ _id: decodedToken._id });
+			const user = await User.findOne({ _id: decodedToken._id }).exec();
+			if (user) {
+				res.status(201).json({ _id: decodedToken._id });
+			} else {
+				res.status(409).json({ message: 'jwt must be provided' });
+			}
 		} catch (error) {
 			res.status(409).json({ message: error.message });
 		}


### PR DESCRIPTION
I found the issue and fixed it here.

The issue was when the browser still has the jwt token but that jwt was created for the user who does **not** exist anymore in our database. 

Since the previous code only checks if that jwt token was the token created through jwt, it didn't matter if the decoded token has the id matching with a certain user in the database.

So, I added the line to check if the decoded token has a valid id. (See lines 11-16) 

Thanks!
